### PR TITLE
Add Claude Code installation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## 開発時の動作確認手順
 
 ```bash
-curl -L -O https://raw.githubusercontent.com/uraitakahito/claude-code-docker/refs/heads/main/Dockerfile
-curl -L -O https://raw.githubusercontent.com/uraitakahito/claude-code-docker/refs/heads/main/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/dotfiles/refs/heads/main/Dockerfile
+curl -L -O https://raw.githubusercontent.com/uraitakahito/dotfiles/refs/heads/main/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -6,6 +6,7 @@ UPGRADE_PACKAGES="${UPGRADEPACKAGES:-"true"}"
 ADD_EZA="${ADDEZA:-"false"}"
 ADD_GRPCURL="${ADDGRPCURL:-"false"}"
 ADD_HADOLINT="${ADDHADOLINT:-"false"}"
+ADD_CLAUDE_CODE="${ADDCLAUDECODE:-"false"}"
 
 if [ "$(id -u)" -ne 0 ]; then
     printf 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.\n'

--- a/utils/main.sh
+++ b/utils/main.sh
@@ -6,6 +6,7 @@ UPGRADE_PACKAGES="${UPGRADEPACKAGES:-"true"}"
 ADD_EZA="${ADDEZA:-"false"}"
 ADD_GRPCURL="${ADDGRPCURL:-"false"}"
 ADD_HADOLINT="${ADDHADOLINT:-"false"}"
+ADD_CLAUDE_CODE="${ADDCLAUDECODE:-"false"}"
 
 MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-packages-ex"
 
@@ -199,6 +200,49 @@ install_alpine_packages() {
     PACKAGES_ALREADY_INSTALLED="true"
 }
 
+# Claude Code (distro-independent)
+install_claude_code() {
+    local target_user="${USERNAME:-""}"
+
+    if [ -z "${target_user}" ]; then
+        echo "Warning: USERNAME is not set. Installing Claude Code for root user."
+        echo "Set USERNAME environment variable to install for a specific user."
+        target_user="root"
+    fi
+
+    if ! id "${target_user}" > /dev/null 2>&1; then
+        echo "Error: User '${target_user}' does not exist."
+        exit 1
+    fi
+
+    if ! command -v curl > /dev/null 2>&1 && ! command -v wget > /dev/null 2>&1; then
+        echo "Error: Either curl or wget is required to install Claude Code."
+        exit 1
+    fi
+
+    echo "Installing Claude Code for user '${target_user}'..."
+
+    # Download installer to a temporary file for safer execution
+    local installer="/tmp/claude-install.sh"
+    if command -v curl > /dev/null 2>&1; then
+        curl -fsSL https://claude.ai/install.sh -o "${installer}"
+    else
+        wget -qO "${installer}" https://claude.ai/install.sh
+    fi
+
+    chmod +x "${installer}"
+
+    if [ "${target_user}" = "root" ]; then
+        bash "${installer}"
+    else
+        su - "${target_user}" -c "bash ${installer}"
+    fi
+
+    rm -f "${installer}"
+
+    echo "Claude Code installed successfully for user '${target_user}'."
+}
+
 # ******************
 # ** Main section **
 # ******************
@@ -236,6 +280,11 @@ case "${ADJUSTED_ID}" in
         install_alpine_packages
         ;;
 esac
+
+# Install Claude Code (distro-independent)
+if [ "${ADD_CLAUDE_CODE}" = "true" ]; then
+    install_claude_code
+fi
 
 # Write marker file
 if [ ! -d "/usr/local/etc/vscode-dev-containers" ]; then


### PR DESCRIPTION
## Summary
- Add `ADDCLAUDECODE=true` option to install Claude Code via extra-utils, eliminating duplicate `curl -fsSL https://claude.ai/install.sh | bash` across multiple Dockerfiles
- Support `USERNAME` env var to install Claude Code for a specific user via `su` (warns and defaults to root if unset)
- Update README.md to reference dotfiles repo instead of claude-code-docker repo

## Test plan
- [ ] Run `shellcheck utils/install.sh utils/main.sh` to verify no lint errors
- [ ] Build Docker image with `ADDCLAUDECODE=true USERNAME=developer` and verify `claude --version` works
- [ ] Build without `ADDCLAUDECODE` and verify Claude Code is not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)