### PR TITLE
Add ADDGITLEAKS opt-in with env-overridable version pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+## 概要
+
+Docker 開発コンテナ向けの追加ユーティリティインストーラー。公式の [features](https://github.com/uraitakahito/features) と組み合わせ、Claude Code を含む開発環境を構築するための補助パッケージ群を提供します。
+
 ## 開発時の動作確認手順
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## 開発時の動作確認手順
 
 ```bash
-curl -L -O https://raw.githubusercontent.com/uraitakahito/dotfiles/refs/heads/main/Dockerfile
-curl -L -O https://raw.githubusercontent.com/uraitakahito/dotfiles/refs/heads/main/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.7/Dockerfile.dev
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.7/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -4,6 +4,7 @@ set -e
 
 UPGRADE_PACKAGES="${UPGRADEPACKAGES:-"true"}"
 ADD_EZA="${ADDEZA:-"false"}"
+ADD_GITLEAKS="${ADDGITLEAKS:-"false"}"
 ADD_GRPCURL="${ADDGRPCURL:-"false"}"
 ADD_HADOLINT="${ADDHADOLINT:-"false"}"
 ADD_MAKE="${ADDMAKE:-"false"}"
@@ -11,6 +12,11 @@ ADD_MAKE="${ADDMAKE:-"false"}"
 # transitively on both Debian/Alpine. See main.sh for full rationale.
 ADD_XXD="${ADDXXD:-"false"}"
 ADD_CLAUDE_CODE="${ADDCLAUDECODE:-"false"}"
+
+# Pinned versions for GitHub-released binaries (env-overridable)
+GITLEAKS_VERSION="${GITLEAKSVERSION:-"8.30.1"}"
+GRPCURL_VERSION="${GRPCURLVERSION:-"1.9.3"}"
+HADOLINT_VERSION="${HADOLINTVERSION:-"2.12.0"}"
 
 if [ "$(id -u)" -ne 0 ]; then
     printf 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.\n'

--- a/utils/main.sh
+++ b/utils/main.sh
@@ -4,6 +4,7 @@ set -e
 
 UPGRADE_PACKAGES="${UPGRADEPACKAGES:-"true"}"
 ADD_EZA="${ADDEZA:-"false"}"
+ADD_GITLEAKS="${ADDGITLEAKS:-"false"}"
 ADD_GRPCURL="${ADDGRPCURL:-"false"}"
 ADD_HADOLINT="${ADDHADOLINT:-"false"}"
 ADD_MAKE="${ADDMAKE:-"false"}"
@@ -24,6 +25,11 @@ ADD_MAKE="${ADDMAKE:-"false"}"
 #   3. API consistency with the other ADD_xxx flags
 ADD_XXD="${ADDXXD:-"false"}"
 ADD_CLAUDE_CODE="${ADDCLAUDECODE:-"false"}"
+
+# Pinned versions for GitHub-released binaries (env-overridable)
+GITLEAKS_VERSION="${GITLEAKSVERSION:-"8.30.1"}"
+GRPCURL_VERSION="${GRPCURLVERSION:-"1.9.3"}"
+HADOLINT_VERSION="${HADOLINTVERSION:-"2.12.0"}"
 
 MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-packages-ex"
 
@@ -70,9 +76,29 @@ install_debian_packages() {
         package_list="${package_list} eza"
     fi
 
+    if [ "${ADD_GITLEAKS}" = "true" ]; then
+        # https://github.com/gitleaks/gitleaks/releases
+        ARCH=$(dpkg --print-architecture)
+        case "${ARCH}" in
+            amd64)
+                GITLEAKS_ARCH="x64"
+                ;;
+            arm64)
+                GITLEAKS_ARCH="arm64"
+                ;;
+            *)
+                echo "Unsupported architecture for gitleaks: ${ARCH}"
+                exit 1
+                ;;
+        esac
+        wget -qO /tmp/gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${GITLEAKS_ARCH}.tar.gz"
+        tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks
+        chmod +x /usr/local/bin/gitleaks
+        rm /tmp/gitleaks.tar.gz
+    fi
+
     if [ "${ADD_GRPCURL}" = "true" ]; then
         # https://github.com/fullstorydev/grpcurl/releases
-        GRPCURL_VERSION="1.9.3"
         ARCH=$(dpkg --print-architecture)
         DEBFILENAME="grpcurl_${GRPCURL_VERSION}_linux_${ARCH}.deb"
         wget -qO /tmp/${DEBFILENAME} https://github.com/fullstorydev/grpcurl/releases/download/v${GRPCURL_VERSION}/${DEBFILENAME}
@@ -83,7 +109,6 @@ install_debian_packages() {
 
     if [ "${ADD_HADOLINT}" = "true" ]; then
         # https://github.com/hadolint/hadolint/releases
-        HADOLINT_VERSION="2.12.0"
         ARCH=$(dpkg --print-architecture)
         case "${ARCH}" in
             amd64)
@@ -187,10 +212,31 @@ install_alpine_packages() {
     apk update
     apk add --no-cache ${package_list}
 
+    # gitleaks (optional) - binary download
+    if [ "${ADD_GITLEAKS}" = "true" ]; then
+        # https://github.com/gitleaks/gitleaks/releases
+        ARCH=$(uname -m)
+        case "${ARCH}" in
+            x86_64)
+                GITLEAKS_ARCH="x64"
+                ;;
+            aarch64)
+                GITLEAKS_ARCH="arm64"
+                ;;
+            *)
+                echo "Unsupported architecture for gitleaks: ${ARCH}"
+                exit 1
+                ;;
+        esac
+        wget -qO /tmp/gitleaks.tar.gz "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_${GITLEAKS_ARCH}.tar.gz"
+        tar -xzf /tmp/gitleaks.tar.gz -C /usr/local/bin gitleaks
+        chmod +x /usr/local/bin/gitleaks
+        rm /tmp/gitleaks.tar.gz
+    fi
+
     # grpcurl (optional) - binary download
     if [ "${ADD_GRPCURL}" = "true" ]; then
         # https://github.com/fullstorydev/grpcurl/releases
-        GRPCURL_VERSION="1.9.3"
         ARCH=$(uname -m)
         case "${ARCH}" in
             x86_64)
@@ -213,7 +259,6 @@ install_alpine_packages() {
     # hadolint (optional) - binary download
     if [ "${ADD_HADOLINT}" = "true" ]; then
         # https://github.com/hadolint/hadolint/releases
-        HADOLINT_VERSION="2.12.0"
         ARCH=$(uname -m)
         case "${ARCH}" in
             x86_64)


### PR DESCRIPTION
## Summary
- New `ADDGITLEAKS` opt-in flag installs gitleaks v8.30.1 from the GitHub releases tarball on both Debian and Alpine.
- All three GitHub-binary version pins (gitleaks / grpcurl / hadolint) are now env-overridable at the top of `install.sh` / `main.sh` (`GITLEAKSVERSION`, `GRPCURLVERSION`, `HADOLINTVERSION`), removing mid-source hardcodes.
- README: add a concise project-overview section; pin setup URLs to tagged `hello-javascript/1.2.7/Dockerfile.dev` instead of floating `dotfiles/main` references.

## Test plan
- [x] `shellcheck utils/install.sh utils/main.sh`
- [x] Default build verified on `debian:bookworm-20251208` (arm64): gitleaks 8.30.1, grpcurl v1.9.3, hadolint 2.12.0
- [x] Default build verified on `alpine:3.21` (arm64): same versions
- [x] Override verified: `GITLEAKSVERSION=8.30.0` yields gitleaks 8.30.0 on Debian

🤖 Generated with [Claude Code](https://claude.com/claude-code)