### PR TITLE
Add ADDYQ opt-in for mikefarah/yq binary install

### DIFF
--- a/utils/install.sh
+++ b/utils/install.sh
@@ -11,12 +11,14 @@ ADD_MAKE="${ADDMAKE:-"false"}"
 # ADD_XXD: opt-in for `xxd`; currently a no-op because `vim` brings xxd in
 # transitively on both Debian/Alpine. See main.sh for full rationale.
 ADD_XXD="${ADDXXD:-"false"}"
+ADD_YQ="${ADDYQ:-"false"}"
 ADD_CLAUDE_CODE="${ADDCLAUDECODE:-"false"}"
 
 # Pinned versions for GitHub-released binaries (env-overridable)
 GITLEAKS_VERSION="${GITLEAKSVERSION:-"8.30.1"}"
 GRPCURL_VERSION="${GRPCURLVERSION:-"1.9.3"}"
 HADOLINT_VERSION="${HADOLINTVERSION:-"2.12.0"}"
+YQ_VERSION="${YQVERSION:-"4.53.2"}"
 
 if [ "$(id -u)" -ne 0 ]; then
     printf 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.\n'

--- a/utils/main.sh
+++ b/utils/main.sh
@@ -24,12 +24,14 @@ ADD_MAKE="${ADDMAKE:-"false"}"
 #      package set, ADDXXD becomes functionally meaningful with no code change
 #   3. API consistency with the other ADD_xxx flags
 ADD_XXD="${ADDXXD:-"false"}"
+ADD_YQ="${ADDYQ:-"false"}"
 ADD_CLAUDE_CODE="${ADDCLAUDECODE:-"false"}"
 
 # Pinned versions for GitHub-released binaries (env-overridable)
 GITLEAKS_VERSION="${GITLEAKSVERSION:-"8.30.1"}"
 GRPCURL_VERSION="${GRPCURLVERSION:-"1.9.3"}"
 HADOLINT_VERSION="${HADOLINTVERSION:-"2.12.0"}"
+YQ_VERSION="${YQVERSION:-"4.53.2"}"
 
 MARKER_FILE="/usr/local/etc/vscode-dev-containers/common-packages-ex"
 
@@ -124,6 +126,25 @@ install_debian_packages() {
         esac
         wget -qO /usr/local/bin/hadolint https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-${HADOLINT_ARCH}
         chmod +x /usr/local/bin/hadolint
+    fi
+
+    if [ "${ADD_YQ}" = "true" ]; then
+        # https://github.com/mikefarah/yq/releases
+        ARCH=$(dpkg --print-architecture)
+        case "${ARCH}" in
+            amd64)
+                YQ_ARCH="amd64"
+                ;;
+            arm64)
+                YQ_ARCH="arm64"
+                ;;
+            *)
+                echo "Unsupported architecture for yq: ${ARCH}"
+                exit 1
+                ;;
+        esac
+        wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${YQ_ARCH}"
+        chmod +x /usr/local/bin/yq
     fi
 
     if [ "${ADD_MAKE}" = "true" ]; then
@@ -274,6 +295,26 @@ install_alpine_packages() {
         esac
         wget -qO /usr/local/bin/hadolint "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-${HADOLINT_ARCH}"
         chmod +x /usr/local/bin/hadolint
+    fi
+
+    # yq (optional) - binary download
+    if [ "${ADD_YQ}" = "true" ]; then
+        # https://github.com/mikefarah/yq/releases
+        ARCH=$(uname -m)
+        case "${ARCH}" in
+            x86_64)
+                YQ_ARCH="amd64"
+                ;;
+            aarch64)
+                YQ_ARCH="arm64"
+                ;;
+            *)
+                echo "Unsupported architecture for yq: ${ARCH}"
+                exit 1
+                ;;
+        esac
+        wget -qO /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_${YQ_ARCH}"
+        chmod +x /usr/local/bin/yq
     fi
 
     # Upgrade packages


### PR DESCRIPTION
## Summary
- Add `ADDYQ` opt-in flag (default `false`) to install **mikefarah/yq** (YAML processor) as an auxiliary tool, mirroring the existing gitleaks/grpcurl/hadolint binary-download pattern.
- Pin `YQ_VERSION` to `4.53.2`, overridable via the `YQVERSION` env var.
- Download the raw `yq_linux_<arch>` binary to `/usr/local/bin/yq` (no tar extraction, like hadolint).
- Debian resolves arch via `dpkg --print-architecture`, Alpine via `uname -m`. yq uses Go-style `amd64`/`arm64` (unlike the siblings' `x64`/`x86_64`), so the arch `case` maps explicitly.

## Test plan
- [x] `shellcheck` on install.sh / main.sh — no findings
- [x] Debian bookworm (arm64 native), `ADDYQ=true` → `yq v4.53.2` at `/usr/local/bin/yq`
- [x] Alpine 3.21 (arm64 native), `ADDYQ=true` → `yq v4.53.2`
- [x] Alpine 3.21 (`linux/amd64` emulated) → `x86_64`→`amd64` mapping → `yq v4.53.2`
- [x] Debian bookworm (`linux/amd64` emulated) → `dpkg amd64` → `yq v4.53.2`, `file` confirms x86-64 ELF
- [x] `YQVERSION=4.52.5` override → `yq v4.52.5`
- [x] Default off (`ADDYQ` unset) → yq not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)