### PR TITLE
Sort ADD_* opt-in flags alphabetically in install.sh

### DIFF
--- a/utils/install.sh
+++ b/utils/install.sh
@@ -3,6 +3,9 @@
 set -e
 
 UPGRADE_PACKAGES="${UPGRADEPACKAGES:-"true"}"
+ADD_CFN_GUARD="${ADDCFNGUARD:-"false"}"
+ADD_CFN_LINT="${ADDCFNLINT:-"false"}"
+ADD_CLAUDE_CODE="${ADDCLAUDECODE:-"false"}"
 ADD_EZA="${ADDEZA:-"false"}"
 ADD_GITLEAKS="${ADDGITLEAKS:-"false"}"
 ADD_GRPCURL="${ADDGRPCURL:-"false"}"
@@ -12,9 +15,6 @@ ADD_MAKE="${ADDMAKE:-"false"}"
 # transitively on both Debian/Alpine. See main.sh for full rationale.
 ADD_XXD="${ADDXXD:-"false"}"
 ADD_YQ="${ADDYQ:-"false"}"
-ADD_CFN_GUARD="${ADDCFNGUARD:-"false"}"
-ADD_CFN_LINT="${ADDCFNLINT:-"false"}"
-ADD_CLAUDE_CODE="${ADDCLAUDECODE:-"false"}"
 
 # Pinned versions for GitHub-released binaries (env-overridable)
 GITLEAKS_VERSION="${GITLEAKSVERSION:-"8.30.1"}"


### PR DESCRIPTION
## Summary
Sorts the `ADD_*` opt-in flag declarations in `utils/install.sh` alphabetically, so newly added flags slot into a predictable position instead of being appended at the end.

Pure reordering of independent variable declarations — **no behavioral change**. (These `install.sh` copies are non-functional anyway: they are not exported, and `main.sh` re-reads the same `ADD*` environment variables itself.)

## Changes
- `utils/install.sh`: move `ADD_CFN_GUARD` / `ADD_CFN_LINT` / `ADD_CLAUDE_CODE` up to keep the block alphabetical (3 insertions, 3 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
