### PR TITLE
Bump hello-javascript dev-harness reference to 1.3.0 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Docker 開発コンテナ向けの追加ユーティリティインストーラ�
 ## 開発時の動作確認手順
 
 ```bash
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.7/Dockerfile.dev
-curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.2.7/docker-entrypoint.sh
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.3.0/Dockerfile.dev
+curl -L -O https://raw.githubusercontent.com/uraitakahito/hello-javascript/refs/tags/1.3.0/docker-entrypoint.sh
 chmod 755 docker-entrypoint.sh
 ```
 


### PR DESCRIPTION
## Summary
Bumps the `hello-javascript` reference in the README's "開発時の動作確認手順" from tag `1.2.7` to `1.3.0` (its latest tag).

## Changes
- `README.md`: the two `curl -L -O` URLs now fetch `Dockerfile.dev` / `docker-entrypoint.sh` from `refs/tags/1.3.0` (2 lines)

## Verification
- Tag `1.3.0` exists (latest) and both raw URLs return **HTTP 200** — confirmed by running the documented `curl` commands as-is
- The fetched `Dockerfile.dev@1.3.0` pins extra-utils 1.3.0 / dotfiles 1.1.9 / pnpm 11.1.3
- No residual `1.2.7` anywhere in the repo; diff is exactly 2 lines
- `docker-entrypoint.sh` is byte-identical between 1.2.7 and 1.3.0 (only `Dockerfile.dev` changed upstream)

The commit-hash permalink under "主な使用例" is intentionally left unchanged (it pins a specific commit, not the tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
