### PR TITLE
Add ADDNGINX opt-in: install_nginx() with runtime-switchable docs root

### DIFF
--- a/utils/docs-root
+++ b/utils/docs-root
@@ -1,0 +1,20 @@
+#!/bin/sh
+#
+# docs-root [DIR] — re-point the Nginx docs root (the /srv/docs symlink) and apply it.
+#
+# The nginx config installed by install_nginx() has a fixed `root /srv/docs;`.
+# This helper repoints that symlink to DIR (default /app) so the served directory
+# can be chosen at runtime without touching the config. Relative paths are
+# normalized to absolute to avoid creating a symlink relative to /srv.
+#
+# Run as root, e.g.:  sudo docs-root /app/private-note/tmp
+#
+set -e
+
+target="${1:-/app}"
+[ -d "${target}" ] || { echo "docs-root: no such directory: ${target}" >&2; exit 1; }
+target="$(cd "${target}" && pwd)"            # normalize to an absolute path
+
+ln -sfn "${target}" /srv/docs                # atomically repoint the served root
+nginx -s reload 2>/dev/null || nginx         # new requests pick it up; start if not running
+echo "docs-root: /srv/docs -> ${target}"

--- a/utils/install.sh
+++ b/utils/install.sh
@@ -11,10 +11,16 @@ ADD_GITLEAKS="${ADDGITLEAKS:-"false"}"
 ADD_GRPCURL="${ADDGRPCURL:-"false"}"
 ADD_HADOLINT="${ADDHADOLINT:-"false"}"
 ADD_MAKE="${ADDMAKE:-"false"}"
+ADD_NGINX="${ADDNGINX:-"false"}"
 # ADD_XXD: opt-in for `xxd`; currently a no-op because `vim` brings xxd in
 # transitively on both Debian/Alpine. See main.sh for full rationale.
 ADD_XXD="${ADDXXD:-"false"}"
 ADD_YQ="${ADDYQ:-"false"}"
+
+# Nginx docs server parameters (env-overridable). NGINX_DOC_ROOT is the default
+# target of the /srv/docs symlink; re-point at runtime with `docs-root <DIR>`.
+NGINX_PORT="${NGINXPORT:-"8080"}"
+NGINX_DOC_ROOT="${NGINXDOCROOT:-"/app"}"
 
 # Pinned versions for GitHub-released binaries (env-overridable)
 GITLEAKS_VERSION="${GITLEAKSVERSION:-"8.30.1"}"

--- a/utils/main.sh
+++ b/utils/main.sh
@@ -8,6 +8,7 @@ ADD_GITLEAKS="${ADDGITLEAKS:-"false"}"
 ADD_GRPCURL="${ADDGRPCURL:-"false"}"
 ADD_HADOLINT="${ADDHADOLINT:-"false"}"
 ADD_MAKE="${ADDMAKE:-"false"}"
+ADD_NGINX="${ADDNGINX:-"false"}"
 # ADD_XXD: opt-in to explicitly include the `xxd` hex-dump utility.
 #
 # History: This flag was added with the intent of providing an opt-in install
@@ -28,6 +29,12 @@ ADD_YQ="${ADDYQ:-"false"}"
 ADD_CFN_GUARD="${ADDCFNGUARD:-"false"}"
 ADD_CFN_LINT="${ADDCFNLINT:-"false"}"
 ADD_CLAUDE_CODE="${ADDCLAUDECODE:-"false"}"
+
+# Nginx docs server parameters (env-overridable). NGINX_DOC_ROOT is the default
+# target of the /srv/docs symlink; the served root can be re-pointed at runtime
+# with `docs-root <DIR>` (see install_nginx).
+NGINX_PORT="${NGINXPORT:-"8080"}"
+NGINX_DOC_ROOT="${NGINXDOCROOT:-"/app"}"
 
 # Pinned versions for GitHub-released binaries (env-overridable)
 GITLEAKS_VERSION="${GITLEAKSVERSION:-"8.30.1"}"
@@ -443,6 +450,53 @@ install_claude_code() {
     echo "Claude Code installed successfully for user '${target_user}'."
 }
 
+# Nginx docs server (distro-independent orchestration).
+# Installs nginx, fixes the served root to the /srv/docs symlink (re-pointable at
+# runtime via docs-root), runs workers as ${USERNAME} so the bind-mounted /app is
+# readable, and ships the docs-root helper onto PATH.
+install_nginx() {
+    local conf_dir nginx_user="${USERNAME:-"root"}"
+
+    case "${ADJUSTED_ID}" in
+        debian)
+            apt-get update -y
+            apt-get -y install --no-install-recommends nginx
+            rm -f /etc/nginx/sites-enabled/default
+            conf_dir="/etc/nginx/conf.d"
+            ;;
+        alpine)
+            apk add --no-cache nginx
+            rm -f /etc/nginx/http.d/default.conf
+            conf_dir="/etc/nginx/http.d"
+            ;;
+    esac
+
+    # Run workers as the /app owner so the bind mount (and the symlink target) is readable.
+    sed -i "s/^user .*/user ${nginx_user};/" /etc/nginx/nginx.conf
+    chown -R "${nginx_user}" /var/lib/nginx /var/log/nginx 2>/dev/null || true
+
+    # Fix the served root to a symlink; the runtime target defaults to ${NGINX_DOC_ROOT}.
+    mkdir -p /srv
+    ln -sfn "${NGINX_DOC_ROOT}" /srv/docs
+
+    cat > "${conf_dir}/docs.conf" <<EOF
+server {
+    listen      0.0.0.0:${NGINX_PORT};
+    server_name _;
+    root        /srv/docs;
+    charset     utf-8;
+    autoindex   on;
+    location / { try_files \$uri \$uri/ =404; }
+}
+EOF
+
+    # Ship the runtime root-switch helper onto PATH ($0 is main.sh, so its dir is utils/).
+    install -m 0755 "$(dirname "$0")/docs-root" /usr/local/bin/docs-root
+
+    nginx -t
+    echo "Nginx ready: root=/srv/docs -> ${NGINX_DOC_ROOT} on :${NGINX_PORT} (worker=${nginx_user})"
+}
+
 # ******************
 # ** Main section **
 # ******************
@@ -489,6 +543,11 @@ fi
 # Install Claude Code (distro-independent)
 if [ "${ADD_CLAUDE_CODE}" = "true" ]; then
     install_claude_code
+fi
+
+# Install Nginx docs server (distro-independent)
+if [ "${ADD_NGINX}" = "true" ]; then
+    install_nginx
 fi
 
 # Write marker file


### PR DESCRIPTION
## Summary

Adds an `ADDNGINX` opt-in that installs nginx and serves a bind-mounted docs directory over HTTP, with a **runtime-switchable** root.

The served root is fixed to a `/srv/docs` symlink; the new `docs-root <DIR>` helper repoints it, so the served directory is chosen when nginx is started manually inside the container — no image rebuild needed.

## Changes

- `main.sh`: declare `ADD_NGINX` / `NGINX_PORT` / `NGINX_DOC_ROOT`, add `install_nginx()` (distro-aware install, fixed `root /srv/docs;`, worker user = `$USERNAME`, ships `docs-root`), and the Main branch.
- `install.sh`: declare the same flags for API consistency.
- `utils/docs-root` (new): repoint `/srv/docs` (absolute-normalized) and reload-or-start nginx.

## Verification (Apple container, Debian bookworm)

- `shellcheck` / `bash -n` clean
- Build with `ADDNGINX=true` passes (build-time `nginx -t` ok)
- `/srv/docs` → `/app`; workers run as the dev user (no 403 on host-owned `/app`)
- `docs-root /app/sub` switches the served root at runtime; nonexistent dir rejected (exit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
